### PR TITLE
[HOPS-406] Rename twelve_month_volume to twelve_month_volume_by_sourc…

### DIFF
--- a/lib/neutrino/gateway/data_quality_report.rb
+++ b/lib/neutrino/gateway/data_quality_report.rb
@@ -16,12 +16,22 @@ module Neutrino
             if_400_raise(Neutrino::Gateway::Exceptions::BadRequestError.new).to_hash
         end
 
-        # Update the twelve month volume report
+        # Update the twelve month volume report by source created at
         # Create a new one if there is no existing report
         # @param [Hash] options specify query values
         # @return [Hash] NEUTRINO response
-        def twelve_month_volume(options = {})
-          path = "#{api}/reports/data-quality/twelve_month_volume"
+        def twelve_month_volume_by_source_created_at(options = {})
+          path = "#{api}/reports/data-quality/twelve_month_volume_by_source_created_at"
+          request(path, options)
+            .if_400_raise(Neutrino::Gateway::Exceptions::BadRequestError.new).to_hash
+        end
+
+        # Update the twelve month volume report by created at
+        # Create a new one if there is no existing report
+        # @param [Hash] options specify query values
+        # @return [Hash] NEUTRINO response
+        def twelve_month_volume_by_created_at(options = {})
+          path = "#{api}/reports/data-quality/twelve_month_volume_by_created_at"
           request(path, options)
             .if_400_raise(Neutrino::Gateway::Exceptions::BadRequestError.new).to_hash
         end

--- a/spec/neutrino/gateway/data_quality_report_spec.rb
+++ b/spec/neutrino/gateway/data_quality_report_spec.rb
@@ -39,33 +39,62 @@ describe Neutrino::Gateway::DataQualityReport do
     end
   end
 
-  describe 'self.twelve_month_volume' do
-    let(:path) { '/api/v1/reports/data-quality/twelve_month_volume' }
+  describe 'self.twelve_month_volume_by_source_created_at' do
     let(:response_message) { { 'content' => 'some data', 'message'=>'The system is updating the report' }  }
 
     before(:each) do
       WebMock.stub_request(
         :get,
-        'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
+        'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume_by_source_created_at?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
         .with(headers: { 'X-Forwarded-For' => REMOTE_IP })
         .to_return(body: response_message.to_json , status: ['200', 'OK'])
     end
 
     it 'returns the expected result' do
-      expect(described_class.twelve_month_volume(OPTIONS_WITH_REMOTE_IP)).to eq(response_message)
+      expect(described_class.twelve_month_volume_by_source_created_at(OPTIONS_WITH_REMOTE_IP)).to eq(response_message)
     end
 
     context 'when the server returns a 400 error' do
       before(:each) do
         WebMock.stub_request(
           :get,
-          'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
+          'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume_by_source_created_at?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
           .with(headers: { 'X-Forwarded-For' => REMOTE_IP })
           .to_return(body: 'Bad Request', status: ['400', 'Bad Request'])
       end
 
       it 'raises a bad request error' do
-        expect { described_class.twelve_month_volume(OPTIONS_WITH_REMOTE_IP) }.to raise_error(Neutrino::Gateway::Exceptions::BadRequestError)
+        expect { described_class.twelve_month_volume_by_source_created_at(OPTIONS_WITH_REMOTE_IP) }.to raise_error(Neutrino::Gateway::Exceptions::BadRequestError)
+      end
+    end
+  end
+
+  describe 'self.twelve_month_volume_by_created_at' do
+    let(:response_message) { { 'content' => 'some data', 'message'=>'The system is updating the report' }  }
+
+    before(:each) do
+      WebMock.stub_request(
+        :get,
+        'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume_by_created_at?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
+        .with(headers: { 'X-Forwarded-For' => REMOTE_IP })
+        .to_return(body: response_message.to_json , status: ['200', 'OK'])
+    end
+
+    it 'returns the expected result' do
+      expect(described_class.twelve_month_volume_by_created_at(OPTIONS_WITH_REMOTE_IP)).to eq(response_message)
+    end
+
+    context 'when the server returns a 400 error' do
+      before(:each) do
+        WebMock.stub_request(
+          :get,
+          'http://testhost:4242/api/v1/reports/data-quality/twelve_month_volume_by_created_at?user%5Bextension%5D=spameggs&user%5Broot%5D=foobar')
+          .with(headers: { 'X-Forwarded-For' => REMOTE_IP })
+          .to_return(body: 'Bad Request', status: ['400', 'Bad Request'])
+      end
+
+      it 'raises a bad request error' do
+        expect { described_class.twelve_month_volume_by_created_at(OPTIONS_WITH_REMOTE_IP) }.to raise_error(Neutrino::Gateway::Exceptions::BadRequestError)
       end
     end
   end


### PR DESCRIPTION
…e_created_at. Introduce twelve_month_volume_by_created_at.

Assumes that twelve_month_volume should be removed, and NOT simply deprecated. This is a breaking change from version 5.1.0, hence the new develop_6.0.0 branch.